### PR TITLE
stop storm ui when enabled

### DIFF
--- a/tasks/stop_nimbus.yml
+++ b/tasks/stop_nimbus.yml
@@ -4,3 +4,5 @@
 
 - name: Stop Storm UI
   service: name=storm-ui state=stopped enabled=yes
+  when: storm_ui_enabled
+


### PR DESCRIPTION
When stopping nimbus, it failed while trying to stop the storm ui, because storm ui was not enabled.  This corrects the problem