### PR TITLE
Fix mode arguments to be octal not decimal numbers

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -6,7 +6,7 @@
   user: name={{storm_user}} system=yes group={{storm_group}}
 
 - name: Create Storm root directory
-  file: path={{storm_root_dir}} state=directory owner={{storm_user}} group={{storm_group}} mode=755
+  file: path={{storm_root_dir}} state=directory owner={{storm_user}} group={{storm_group}} mode=0755
 
 - name: Uncompress the storm tar
   unarchive: copy=no creates={{storm_root_dir}}/apache-storm-{{storm_version}} dest={{storm_root_dir}} src={{ download_tmp_dir }}/apache-storm-{{storm_version}}.tar.gz
@@ -15,7 +15,7 @@
   file: path={{storm_root_dir}}/current state=link src={{storm_root_dir}}/apache-storm-{{storm_version}}
 
 - name: Create Storm log and local directories
-  file: path={{item}} state=directory owner={{storm_user}} group={{storm_group}} mode=775
+  file: path={{item}} state=directory owner={{storm_user}} group={{storm_group}} mode=0775
   with_items:
     - "{{storm_local_dir}}"
     - "/var/log/storm"
@@ -41,7 +41,7 @@
   when: init.stdout != 'systemd'
 
 - name: Configure cluster.xml for setting log level
-  template: dest="{{storm_root_dir}}/apache-storm-{{storm_version}}/logback/cluster.xml" owner={{storm_user}} group={{storm_group}} mode=644 src=cluster.xml.j2
+  template: dest="{{storm_root_dir}}/apache-storm-{{storm_version}}/logback/cluster.xml" owner={{storm_user}} group={{storm_group}} mode=0644 src=cluster.xml.j2
   notify:
     - Restart Nimbus
     - Restart Supervisor

--- a/tasks/configure_nimbus.yml
+++ b/tasks/configure_nimbus.yml
@@ -1,30 +1,30 @@
 ---
 - name: Configure storm.yaml
-  template: dest="{{storm_root_dir}}/apache-storm-{{storm_version}}/conf/storm.yaml" owner={{storm_user}} group={{storm_group}} mode=644 src=storm.yaml.j2
+  template: dest="{{storm_root_dir}}/apache-storm-{{storm_version}}/conf/storm.yaml" owner={{storm_user}} group={{storm_group}} mode=0644 src=storm.yaml.j2
   notify:
     - Restart Nimbus
     - Restart UI
 
 - name: Setup Storm nimbus upstart script
-  copy: dest={{nimbus_upstart_conf}} owner=root group=root mode=644 src=storm-nimbus.conf
+  copy: dest={{nimbus_upstart_conf}} owner=root group=root mode=0644 src=storm-nimbus.conf
   notify:
     - Restart Nimbus
   when: not use_systemd
 
 - name: Setup Storm nimbus systemd script
-  copy: dest={{nimbus_systemd_service}} owner=root group=root mode=644 src=storm-nimbus.service
+  copy: dest={{nimbus_systemd_service}} owner=root group=root mode=0644 src=storm-nimbus.service
   notify:
     - Restart Nimbus
   when: use_systemd
 
 - name: Setup Storm UI upstart script
-  copy: dest={{stormui_upstart_conf}} owner=root group=root mode=644 src=storm-ui.conf
+  copy: dest={{stormui_upstart_conf}} owner=root group=root mode=0644 src=storm-ui.conf
   notify:
     - Restart UI
   when: storm_ui_enabled and not use_systemd
 
 - name: Setup Storm UI systemd script
-  copy: dest={{stormui_systemd_service}} owner=root group=root mode=644 src=storm-ui.service
+  copy: dest={{stormui_systemd_service}} owner=root group=root mode=0644 src=storm-ui.service
   notify:
     - Restart UI
   when: storm_ui_enabled and use_systemd

--- a/tasks/configure_supervisor.yml
+++ b/tasks/configure_supervisor.yml
@@ -1,29 +1,29 @@
 ---
 - name: Configure storm.yaml
-  template: dest="{{storm_root_dir}}/apache-storm-{{storm_version}}/conf/storm.yaml" owner={{storm_user}} group={{storm_group}} mode=644 src=storm.yaml.j2
+  template: dest="{{storm_root_dir}}/apache-storm-{{storm_version}}/conf/storm.yaml" owner={{storm_user}} group={{storm_group}} mode=0644 src=storm.yaml.j2
   notify:
     - Restart Supervisor
 
 - name: Setup Storm supervisor upstart script
-  copy: dest={{supervisor_upstart_conf}} owner=root group=root mode=644 src=storm-supervisor.conf
+  copy: dest={{supervisor_upstart_conf}} owner=root group=root mode=0644 src=storm-supervisor.conf
   notify:
     - Restart Supervisor
   when: not use_systemd
 
 - name: Setup Storm supervisor systemd script
-  copy: dest={{supervisor_systemd_service}} owner=root group=root mode=644 src=storm-supervisor.service
+  copy: dest={{supervisor_systemd_service}} owner=root group=root mode=0644 src=storm-supervisor.service
   notify:
     - Restart Supervisor
   when: use_systemd
 
 - name: Setup Storm Logviewer upstart script
-  copy: dest={{logviewer_upstart_conf}} owner=root group=root mode=644 src=storm-logviewer.conf
+  copy: dest={{logviewer_upstart_conf}} owner=root group=root mode=0644 src=storm-logviewer.conf
   notify:
     - Restart Logviewer
   when: storm_logviewer_enabled and not use_systemd
 
 - name: Setup Storm Logviewer systemd script
-  copy: dest={{logviewer_systemd_service}} owner=root group=root mode=644 src=storm-logviewer.service
+  copy: dest={{logviewer_systemd_service}} owner=root group=root mode=0644 src=storm-logviewer.service
   notify:
     - Restart Logviewer
   when: storm_logviewer_enabled and use_systemd


### PR DESCRIPTION
From the ansible documentation:
"For those used to /usr/bin/chmod remember that modes are
actually octal numbers (like 0644). Leaving off the leading
zero will likely have unexpected results."
